### PR TITLE
#25 로그인 만료시 로그인 페이지로 가지 않던 오류 수정

### DIFF
--- a/src/services/auth_service.js
+++ b/src/services/auth_service.js
@@ -107,6 +107,7 @@ class AuthService {
             return true;
         }catch(error){
             console.log(error);
+            localStorage.removeItem("user");
             return false;
         }
     }

--- a/src/services/auth_service.js
+++ b/src/services/auth_service.js
@@ -44,14 +44,14 @@ class AuthService {
     
             this.axiosApi.post("/account/logout/", data)
             .then(response => {
-                    removeRefreshToken();
-                    // localStorage 정보 삭제
-                    localStorage.clear();
-                    onLogout();
-                })
-                .catch(error => {
-                    console.log(error);
-                })
+                removeRefreshToken();
+                // localStorage 정보 삭제
+                localStorage.clear();
+                onLogout();
+            })
+            .catch(error => {
+                console.log(error);
+            })
         }
     }
 


### PR DESCRIPTION
로컬스토리지를 삭제하지 않아 로그인이 만료돼도 로그인 페이지로 가지지 않던 오류를 수정
(로그인 페이지로 이동은 되나 로컬스토리지에 유저정보가 남아있어 다시 메인페이지로 돌아오는 거였음)